### PR TITLE
Rename env var to SUPERMEMORY_CLAWDBOT_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The only required value is your Supermemory API key. Get one at [console.superme
 Set it as an environment variable:
 
 ```bash
-export SUPERMEMORY_API_KEY="sm_..."
+export SUPERMEMORY_CLAWDBOT_API_KEY="sm_..."
 ```
 
 Or configure it directly in `clawdbot.json`:
@@ -29,7 +29,7 @@ Or configure it directly in `clawdbot.json`:
       "clawdbot-supermemory": {
         "enabled": true,
         "config": {
-          "apiKey": "${SUPERMEMORY_API_KEY}"
+          "apiKey": "${SUPERMEMORY_CLAWDBOT_API_KEY}"
         }
       }
     }

--- a/clawdbot.plugin.json
+++ b/clawdbot.plugin.json
@@ -6,7 +6,7 @@
 			"label": "Supermemory API Key",
 			"sensitive": true,
 			"placeholder": "sm_...",
-			"help": "Your API key from console.supermemory.ai (or use ${SUPERMEMORY_API_KEY})"
+			"help": "Your API key from console.supermemory.ai (or use ${SUPERMEMORY_CLAWDBOT_API_KEY})"
 		},
 		"containerTag": {
 			"label": "Container Tag",

--- a/config.ts
+++ b/config.ts
@@ -69,11 +69,11 @@ export function parseConfig(raw: unknown): SupermemoryConfig {
 	const apiKey =
 		typeof cfg.apiKey === "string" && cfg.apiKey.length > 0
 			? resolveEnvVars(cfg.apiKey)
-			: process.env.SUPERMEMORY_API_KEY
+			: process.env.SUPERMEMORY_CLAWDBOT_API_KEY
 
 	if (!apiKey) {
 		throw new Error(
-			"supermemory: apiKey is required (set in plugin config or SUPERMEMORY_API_KEY env var)",
+			"supermemory: apiKey is required (set in plugin config or SUPERMEMORY_CLAWDBOT_API_KEY env var)",
 		)
 	}
 


### PR DESCRIPTION
Disambiguate env var name for plugin-specific API key

- Renamed SUPERMEMORY_API_KEY to SUPERMEMORY_CLAWDBOT_API_KEY in config