### PR TITLE
fix: add entity context for memory extraction and skip cron, exec providers

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -62,6 +62,7 @@ export class SupermemoryClient {
 		metadata?: Record<string, string | number | boolean>,
 		customId?: string,
 		containerTag?: string,
+		entityContext?: string,
 	): Promise<{ id: string }> {
 		const cleaned = sanitizeContent(content)
 		const tag = containerTag ?? this.containerTag
@@ -78,6 +79,7 @@ export class SupermemoryClient {
 			containerTag: tag,
 			...(metadata && { metadata }),
 			...(customId && { customId }),
+			...(entityContext && { entityContext }),
 		})
 
 		log.debugResponse("add", { id: result.id })

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -107,9 +107,9 @@ function formatContext(
 	}
 
 	const intro =
-		"The following is recalled context about the user. Reference it only when relevant to the conversation."
+		"The following is background context about the user from long-term memory. Use this context silently to inform your understanding — only reference it when the user's message is directly related to something in these memories."
 	const disclaimer =
-		"Use these memories naturally when relevant — including indirect connections — but don't force them into every response or make assumptions beyond what's stated."
+		"Do not proactively bring up memories. Only use them when the conversation naturally calls for it."
 
 	return `<supermemory-context>\n${intro}\n\n${sections.join("\n\n")}\n\n${disclaimer}\n</supermemory-context>`
 }

--- a/memory.ts
+++ b/memory.ts
@@ -16,6 +16,9 @@ export function detectCategory(text: string): MemoryCategory {
 	return "other"
 }
 
+export const ENTITY_CONTEXT =
+	"Messages are tagged with [role: user] and [role: assistant]. Only create memories from what the user actually said — their preferences, decisions, and important personal details. Agent (assistant) responses are just context, not facts to remember. Only remember things that will be useful later. Ignore noise like greetings or status updates."
+
 export function buildDocumentId(sessionKey: string): string {
 	const sanitized = sessionKey
 		.replace(/[^a-zA-Z0-9_]/g, "_")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@supermemory/openclaw-supermemory",
-	"version": "1.0.5",
+	"version": "2.0.0",
 	"type": "module",
 	"description": "OpenClaw Supermemory memory plugin",
 	"license": "MIT",


### PR DESCRIPTION
### Improvements for openclaw-supermemory v2

- memory.ts — Added ENTITY_CONTEXT that tells Supermemory to only create memories from user messages, treat agent responses as context, and ignore noise
  like greetings/status updates
 - client.ts — Added entityContext parameter to addMemory() so it gets passed through to the Supermemory API
  - hooks/capture.ts — Skip capturing heartbeat, cron-event, and exec-event agent turns. Pass ENTITY_CONTEXT on every capture. Added logging to track what
  gets captured vs skipped
  - hooks/recall.ts — Tightened the memory injection prompt so the agent uses recalled memories silently and only surfaces them when the conversation
  naturally calls for it