### PR TITLE
fix: harden search/forget behavior and skip capture for memory-management turns

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -32,6 +32,81 @@ function limitText(text: string, max: number): string {
 	return text.length > max ? `${text.slice(0, max)}…` : text
 }
 
+export function normalizeMemoryText(text: string | undefined): string {
+	return sanitizeContent(text ?? "")
+		.trim()
+		.replace(/\s+/g, " ")
+		.toLowerCase()
+}
+
+function getQueryTokens(normalizedQuery: string): string[] {
+	if (!normalizedQuery) return []
+	return normalizedQuery.split(/\s+/).filter(Boolean)
+}
+
+function getTokenCoverage(
+	normalizedText: string,
+	queryTokens: string[],
+): number {
+	if (queryTokens.length === 0) return 0
+	const matched = queryTokens.filter((token) =>
+		normalizedText.includes(token),
+	).length
+	return matched / queryTokens.length
+}
+
+export function findExactContentMatch(
+	results: SearchResult[],
+	query: string,
+): SearchResult | undefined {
+	const normalizedQuery = normalizeMemoryText(query)
+	if (!normalizedQuery) return undefined
+
+	return results.find(
+		(result) =>
+			normalizeMemoryText(result.content || result.memory) === normalizedQuery,
+	)
+}
+
+export function rerankSearchResults(
+	query: string,
+	results: SearchResult[],
+): SearchResult[] {
+	const normalizedQuery = normalizeMemoryText(query)
+	if (!normalizedQuery || results.length <= 1) return results
+
+	const queryTokens = getQueryTokens(normalizedQuery)
+
+	return [...results]
+		.map((result, index) => {
+			const normalizedContent = normalizeMemoryText(
+				result.content || result.memory,
+			)
+			return {
+				index,
+				result,
+				exact: normalizedContent === normalizedQuery ? 1 : 0,
+				contains: normalizedContent.includes(normalizedQuery) ? 1 : 0,
+				tokenCoverage: getTokenCoverage(normalizedContent, queryTokens),
+				similarity: result.similarity ?? 0,
+				contentLength: normalizedContent.length || Number.MAX_SAFE_INTEGER,
+			}
+		})
+		.sort((a, b) => {
+			if (b.exact !== a.exact) return b.exact - a.exact
+			if (b.contains !== a.contains) return b.contains - a.contains
+			if (b.tokenCoverage !== a.tokenCoverage) {
+				return b.tokenCoverage - a.tokenCoverage
+			}
+			if (b.similarity !== a.similarity) return b.similarity - a.similarity
+			if (a.contentLength !== b.contentLength) {
+				return a.contentLength - b.contentLength
+			}
+			return a.index - b.index
+		})
+		.map(({ result }) => result)
+}
+
 export class SupermemoryClient {
 	private client: Supermemory
 	private containerTag: string
@@ -90,27 +165,31 @@ export class SupermemoryClient {
 		limit = 5,
 		containerTag?: string,
 	): Promise<SearchResult[]> {
+		const cleanedQuery = sanitizeContent(query)
 		const tag = containerTag ?? this.containerTag
 
 		log.debugRequest("search.memories", {
-			query,
+			query: cleanedQuery,
 			limit,
 			containerTag: tag,
 		})
 
 		const response = await this.client.search.memories({
-			q: query,
+			q: cleanedQuery,
 			containerTag: tag,
 			limit,
+			rerank: true,
+			rewriteQuery: false,
 		})
 
-		const results: SearchResult[] = (response.results ?? []).map((r) => ({
+		const rawResults: SearchResult[] = (response.results ?? []).map((r) => ({
 			id: r.id,
 			content: r.memory ?? "",
 			memory: r.memory,
 			similarity: r.similarity,
 			metadata: r.metadata ?? undefined,
 		}))
+		const results = rerankSearchResults(cleanedQuery, rawResults)
 
 		log.debugResponse("search.memories", { count: results.length })
 		return results
@@ -168,17 +247,25 @@ export class SupermemoryClient {
 		query: string,
 		containerTag?: string,
 	): Promise<{ success: boolean; message: string }> {
-		log.debugRequest("forgetByQuery", { query, containerTag })
+		const cleanedQuery = sanitizeContent(query)
+		log.debugRequest("forgetByQuery", { query: cleanedQuery, containerTag })
 
-		const results = await this.search(query, 5, containerTag)
+		const results = await this.search(cleanedQuery, 10, containerTag)
 		if (results.length === 0) {
 			return { success: false, message: "No matching memory found to forget." }
 		}
 
-		const target = results[0]
-		await this.deleteMemory(target.id, containerTag)
+		const target = findExactContentMatch(results, cleanedQuery) ?? results[0]
+		const deleted = await this.deleteMemory(target.id, containerTag)
 
 		const preview = limitText(target.content || target.memory || "", 100)
+		if (!deleted.forgotten) {
+			return {
+				success: false,
+				message: `Unable to confirm forgetting: "${preview}"`,
+			}
+		}
+
 		return { success: true, message: `Forgot: "${preview}"` }
 	}
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -4,6 +4,17 @@ import { log } from "../logger.ts"
 import { buildDocumentId } from "../memory.ts"
 
 const SKIPPED_PROVIDERS = ["exec-event", "cron-event", "heartbeat"]
+const MEMORY_TOOL_PREFIX = "supermemory_"
+const MEMORY_COMMAND_PREFIXES = ["/remember", "/recall"]
+const MEMORY_TOOL_RESPONSE_PATTERNS = [
+	/^Stored:\s*"/i,
+	/^Forgot:\s*"/i,
+	/^Found \d+ memories:/i,
+	/^No relevant memories found\.?$/i,
+	/^No matching memory found to forget\.?$/i,
+	/^Memory forgotten\.?$/i,
+	/^Provide a query or memoryId to forget\.?$/i,
+]
 
 function getLastTurn(messages: unknown[]): unknown[] {
 	let lastUserIdx = -1
@@ -19,6 +30,89 @@ function getLastTurn(messages: unknown[]): unknown[] {
 		}
 	}
 	return lastUserIdx >= 0 ? messages.slice(lastUserIdx) : messages
+}
+
+function collectTextParts(content: unknown): string[] {
+	const parts: string[] = []
+
+	if (typeof content === "string") {
+		parts.push(content)
+		return parts
+	}
+
+	if (!Array.isArray(content)) return parts
+
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue
+		const b = block as Record<string, unknown>
+		if (b.type === "text" && typeof b.text === "string") {
+			parts.push(b.text)
+		}
+	}
+
+	return parts
+}
+
+function messageReferencesSupermemoryTool(
+	msgObj: Record<string, unknown>,
+): boolean {
+	for (const key of ["name", "toolName"]) {
+		if (
+			typeof msgObj[key] === "string" &&
+			(msgObj[key] as string).startsWith(MEMORY_TOOL_PREFIX)
+		) {
+			return true
+		}
+	}
+
+	const content = msgObj.content
+	if (!Array.isArray(content)) return false
+
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue
+		const b = block as Record<string, unknown>
+		if (typeof b.name === "string" && b.name.startsWith(MEMORY_TOOL_PREFIX)) {
+			return true
+		}
+		if (
+			typeof b.toolName === "string" &&
+			b.toolName.startsWith(MEMORY_TOOL_PREFIX)
+		) {
+			return true
+		}
+	}
+
+	return false
+}
+
+export function isSupermemoryManagementTurn(messages: unknown[]): boolean {
+	for (const msg of messages) {
+		if (!msg || typeof msg !== "object") continue
+		const msgObj = msg as Record<string, unknown>
+
+		if (messageReferencesSupermemoryTool(msgObj)) {
+			return true
+		}
+
+		for (const text of collectTextParts(msgObj.content)) {
+			const trimmed = text.trim()
+			const lower = trimmed.toLowerCase()
+			if (
+				MEMORY_COMMAND_PREFIXES.some(
+					(prefix) => lower === prefix || lower.startsWith(`${prefix} `),
+				)
+			) {
+				return true
+			}
+			if (
+				MEMORY_TOOL_RESPONSE_PATTERNS.some((pattern) => pattern.test(trimmed))
+			) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 export function buildCaptureHandler(
@@ -46,6 +140,10 @@ export function buildCaptureHandler(
 			return
 
 		const lastTurn = getLastTurn(event.messages)
+		if (isSupermemoryManagementTurn(lastTurn)) {
+			log.debug("capture: skipping supermemory management turn")
+			return
+		}
 
 		const texts: string[] = []
 		for (const msg of lastTurn) {
@@ -54,21 +152,7 @@ export function buildCaptureHandler(
 			const role = msgObj.role
 			if (role !== "user" && role !== "assistant") continue
 
-			const content = msgObj.content
-
-			const parts: string[] = []
-
-			if (typeof content === "string") {
-				parts.push(content)
-			} else if (Array.isArray(content)) {
-				for (const block of content) {
-					if (!block || typeof block !== "object") continue
-					const b = block as Record<string, unknown>
-					if (b.type === "text" && typeof b.text === "string") {
-						parts.push(b.text)
-					}
-				}
-			}
+			const parts = collectTextParts(msgObj.content)
 
 			if (parts.length > 0) {
 				texts.push(`[role: ${role}]\n${parts.join("\n")}\n[${role}:end]`)

--- a/tests/capture.test.ts
+++ b/tests/capture.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test"
+import type { SupermemoryClient } from "../client.ts"
+import type { SupermemoryConfig } from "../config.ts"
+import {
+	buildCaptureHandler,
+	isSupermemoryManagementTurn,
+} from "../hooks/capture.ts"
+
+const cfg: SupermemoryConfig = {
+	apiKey: undefined,
+	containerTag: "test_container",
+	autoRecall: true,
+	autoCapture: true,
+	maxRecallResults: 10,
+	profileFrequency: 50,
+	captureMode: "all",
+	entityContext: "test context",
+	debug: false,
+	enableCustomContainerTags: false,
+	customContainers: [],
+	customContainerInstructions: "",
+}
+
+type CaptureArgs = [
+	content: string,
+	metadata?: Record<string, string | number | boolean>,
+	customId?: string,
+	containerTag?: string,
+	entityContext?: string,
+]
+
+type CaptureClient = Pick<SupermemoryClient, "addMemory">
+
+describe("capture hook", () => {
+	it("detects turns that manage supermemory directly", () => {
+		const turn = [
+			{ role: "user", content: "Please forget this memory." },
+			{
+				role: "assistant",
+				content: [
+					{
+						type: "tool_call",
+						name: "supermemory_forget",
+						arguments: { query: "foo" },
+					},
+				],
+			},
+			{ role: "assistant", content: 'Forgot: "foo"' },
+		]
+
+		expect(isSupermemoryManagementTurn(turn)).toBe(true)
+	})
+
+	it("skips capturing turns that used supermemory tools", async () => {
+		const calls: CaptureArgs[] = []
+		const client: CaptureClient = {
+			addMemory: async (...args) => {
+				calls.push(args)
+				return { id: "memory_1" }
+			},
+		}
+		const handler = buildCaptureHandler(
+			client as unknown as SupermemoryClient,
+			cfg,
+			() => "session-123",
+		)
+
+		await handler(
+			{
+				success: true,
+				messages: [
+					{ role: "user", content: "Please forget this memory." },
+					{
+						role: "assistant",
+						content: [
+							{
+								type: "tool_call",
+								name: "supermemory_forget",
+								arguments: { query: "foo" },
+							},
+						],
+					},
+					{ role: "assistant", content: 'Forgot: "foo"' },
+				],
+			},
+			{ messageProvider: "discord" },
+		)
+
+		expect(calls.length).toBe(0)
+	})
+
+	it("still captures normal conversational turns", async () => {
+		const calls: CaptureArgs[] = []
+		const client: CaptureClient = {
+			addMemory: async (...args) => {
+				calls.push(args)
+				return { id: "memory_1" }
+			},
+		}
+		const handler = buildCaptureHandler(
+			client as unknown as SupermemoryClient,
+			cfg,
+			() => "session-123",
+		)
+
+		await handler(
+			{
+				success: true,
+				messages: [
+					{ role: "user", content: "My favorite editor is Helix." },
+					{ role: "assistant", content: "Got it." },
+				],
+			},
+			{ messageProvider: "discord" },
+		)
+
+		expect(calls.length).toBe(1)
+		const [content, metadata, customId] = calls[0]
+		expect(content).toContain("My favorite editor is Helix.")
+		expect(content).toContain("Got it.")
+		expect(metadata).toEqual(expect.objectContaining({ source: "openclaw" }))
+		expect(customId).toBe("session_session_123")
+	})
+})

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test"
+import type { SearchResult } from "../client.ts"
+import { SupermemoryClient } from "../client.ts"
+
+const API_KEY = "sm_12345678901234567890"
+
+describe("SupermemoryClient", () => {
+	it("ranks exact literal matches ahead of higher-similarity fuzzy matches", async () => {
+		const query = "OPENCLAW_SUPERMEMORY_HEALTHCHECK_2026-03-14_1459"
+		const client = new SupermemoryClient(API_KEY, "test_container")
+
+		Reflect.set(client as object, "client", {
+			search: {
+				memories: async () => ({
+					results: [
+						{
+							id: "allowlist",
+							memory: "openclaw-supermemory allowlist note",
+							similarity: 0.97,
+							metadata: null,
+						},
+						{
+							id: "exact",
+							memory: query,
+							similarity: 0.25,
+							metadata: null,
+						},
+					],
+				}),
+			},
+		})
+
+		const results = await client.search(query)
+
+		expect(results[0]?.id).toBe("exact")
+	})
+
+	it("prefers an exact textual match when forgetting by query", async () => {
+		const query = "OPENCLAW_SUPERMEMORY_HEALTHCHECK_2026-03-14_1459"
+		const client = new SupermemoryClient(API_KEY, "test_container")
+		const deletedIds: string[] = []
+
+		Reflect.set(
+			client as object,
+			"search",
+			async (): Promise<SearchResult[]> => [
+				{
+					id: "allowlist",
+					content: "openclaw-supermemory allowlist note",
+					similarity: 0.99,
+				},
+				{
+					id: "exact",
+					content: query,
+					similarity: 0.21,
+				},
+			],
+		)
+		Reflect.set(client as object, "deleteMemory", async (id: string) => {
+			deletedIds.push(id)
+			return { id, forgotten: true }
+		})
+
+		const result = await client.forgetByQuery(query)
+
+		expect(deletedIds).toEqual(["exact"])
+		expect(result).toEqual({ success: true, message: `Forgot: "${query}"` })
+	})
+
+	it("does not claim success when the delete result cannot be confirmed", async () => {
+		const query = "OPENCLAW_SUPERMEMORY_HEALTHCHECK_2026-03-14_1459"
+		const client = new SupermemoryClient(API_KEY, "test_container")
+
+		Reflect.set(
+			client as object,
+			"search",
+			async (): Promise<SearchResult[]> => [
+				{
+					id: "exact",
+					content: query,
+					similarity: 0.42,
+				},
+			],
+		)
+		Reflect.set(client as object, "deleteMemory", async (id: string) => ({
+			id,
+			forgotten: false,
+		}))
+
+		const result = await client.forgetByQuery(query)
+
+		expect(result.success).toBe(false)
+		expect(result.message).toContain("Unable to confirm forgetting")
+	})
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
 		"tools/*.ts",
 		"hooks/*.ts",
 		"commands/*.ts",
+		"tests/*.ts",
 		"types/*.d.ts",
 		"lib/*.d.ts"
 	],


### PR DESCRIPTION
## Summary
- stop auto-capturing Supermemory management turns (`search` / `forget` / `store`) back into memory
- make `forgetByQuery()` safer by avoiding blind deletion of the first semantic hit
- locally rerank search results so exact/literal matches are preferred when they are already present in the candidate set
- only report forget success when the backend explicitly confirms `forgotten === true`
- add focused regression tests for safer forget behavior and capture skipping

## Why this PR exists

This plugin currently has a few failure modes around `search` / `forget` that make memory management feel less trustworthy than it should:

1. `forgetByQuery()` can delete the wrong memory because it trusts the first semantic search hit too much.
2. Exact/literal matches are not preferred locally, even when they are already present in the returned result set.
3. Memory-management turns themselves can get auto-captured again, which reintroduces deletion/search text as fresh memory-like context and creates meta-memory pollution.

## Scope of this fix

This PR is intentionally a **plugin-layer hardening pass**, not a claim that all search/delete ambiguity is fully solved end-to-end.

In particular, this change improves behavior when:
- the correct target is already present in the returned candidate set
- the plugin would otherwise delete the first fuzzy match too eagerly
- management-turn text would otherwise be captured back into memory

It does **not** try to redesign or over-assume the backend’s broader memory extraction semantics.

## What changed

### `client.ts`
- add local normalization helpers
- rerank returned search candidates to prefer exact/literal matches before fuzzier semantic neighbors
- make `forgetByQuery()` search a wider candidate set and prefer an exact textual match when available
- require explicit backend confirmation (`forgotten === true`) before reporting forget success

### `hooks/capture.ts`
- detect Supermemory management turns
- skip auto-capture for these turns so search/forget/store operations do not feed their own management text back into memory

### Tests
Added focused regression coverage for:
- exact-match preference within returned search candidates
- safer `forgetByQuery()` target selection
- forget success acknowledgement handling
- skipping capture for memory-management turns

## Root cause addressed here

This patch addresses three concrete plugin-level issues:

1. **Blind first-result deletion**
   - `forgetByQuery()` effectively searched and deleted `results[0]`
   - that is too optimistic for a semantically ranked system

2. **No exact-match preference**
   - exact/literal matches in the result set were not locally boosted

3. **Management-turn recapture**
   - search/forget/store interactions could be auto-captured back into memory, creating ghost/meta-memory artifacts

## Why the fix is intentionally conservative

I deliberately kept this patch small and local to the plugin.

There may still be broader API-/backend-level behaviors (for example asynchronous extraction or memory text normalization/canonicalization) that affect how quickly or how literally a newly added memory can be searched or forgotten.

This PR does not attempt to solve those larger semantics in the plugin layer.
Instead, it makes the plugin safer and less misleading under the assumptions it can control today.

## Testing
```bash
bun test
bun run check-types
bun run lint
```

All passed locally.
```
