### PR TITLE
Add memory usage display toggle feature

### DIFF
--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -190,6 +190,26 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 						console.log("  Invalid value, using default: all")
 					}
 
+					console.log("\nMemory usage display:")
+					console.log(
+						"  true  - Show how many memories were used in each response (recommended)",
+					)
+					console.log(
+						"  false - Hide memory usage counts from responses",
+					)
+					const showMemoryUsageInput = await ask(
+						"Show memory usage (true/false) [true]: ",
+					)
+					let showMemoryUsage = true
+					if (showMemoryUsageInput.trim().toLowerCase() === "false") {
+						showMemoryUsage = false
+					} else if (
+						showMemoryUsageInput.trim() &&
+						showMemoryUsageInput.trim().toLowerCase() !== "true"
+					) {
+						console.log("  Invalid value, using default: true")
+					}
+
 					console.log("\nEntity context:")
 					console.log(
 						"  Instructions that guide what memories are extracted from conversations.",
@@ -275,6 +295,7 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 					if (profileFrequency !== 50)
 						pluginConfig.profileFrequency = profileFrequency
 					if (captureMode !== "all") pluginConfig.captureMode = captureMode
+					if (!showMemoryUsage) pluginConfig.showMemoryUsage = false
 					if (entityContextInput.trim())
 						pluginConfig.entityContext = entityContextInput.trim()
 					if (enableCustomContainerTags)
@@ -311,6 +332,7 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 					console.log(`  Max results:      ${maxRecallResults}`)
 					console.log(`  Profile freq:     ${profileFrequency}`)
 					console.log(`  Capture mode:     ${captureMode}`)
+					console.log(`  Memory usage:     ${showMemoryUsage}`)
 					const entityPreview = entityContextInput.trim()
 					if (entityPreview) {
 						const truncated =
@@ -403,6 +425,9 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 					)
 					console.log(
 						`  Capture mode:     ${pluginConfig.captureMode ?? "all"}`,
+					)
+					console.log(
+						`  Memory usage:     ${pluginConfig.showMemoryUsage ?? true}`,
 					)
 					const entityCtx = pluginConfig.entityContext as string | undefined
 					if (entityCtx) {

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -194,9 +194,7 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 					console.log(
 						"  true  - Show how many memories were used in each response (recommended)",
 					)
-					console.log(
-						"  false - Hide memory usage counts from responses",
-					)
+					console.log("  false - Hide memory usage counts from responses")
 					const showMemoryUsageInput = await ask(
 						"Show memory usage (true/false) [true]: ",
 					)

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -37,6 +37,31 @@ export function registerCommands(
 	getSessionKey: () => string | undefined,
 ): void {
 	api.registerCommand({
+		name: "memory-usage",
+		description: "Toggle memory usage display on/off",
+		acceptsArgs: true,
+		requireAuth: false,
+		handler: async (ctx: { args?: string }) => {
+			const arg = ctx.args?.trim().toLowerCase()
+
+			if (arg === "on" || arg === "true" || arg === "enable") {
+				cfg.showMemoryUsage = true
+				return { text: "Memory usage display enabled. The model will now show how many memories were used." }
+			}
+
+			if (arg === "off" || arg === "false" || arg === "disable") {
+				cfg.showMemoryUsage = false
+				return { text: "Memory usage display disabled. The model will no longer show memory counts." }
+			}
+
+			// No arg or unrecognized: toggle
+			cfg.showMemoryUsage = !cfg.showMemoryUsage
+			const state = cfg.showMemoryUsage ? "enabled" : "disabled"
+			return { text: `Memory usage display ${state}. Use /memory-usage on|off to set explicitly.` }
+		},
+	})
+
+	api.registerCommand({
 		name: "remember",
 		description: "Save something to memory",
 		acceptsArgs: true,

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -54,10 +54,15 @@ export function registerCommands(
 				return { text: "Memory usage display disabled. The model will no longer show memory counts." }
 			}
 
-			// No arg or unrecognized: toggle
-			cfg.showMemoryUsage = !cfg.showMemoryUsage
-			const state = cfg.showMemoryUsage ? "enabled" : "disabled"
-			return { text: `Memory usage display ${state}. Use /memory-usage on|off to set explicitly.` }
+			if (!arg) {
+				cfg.showMemoryUsage = !cfg.showMemoryUsage
+				const state = cfg.showMemoryUsage ? "enabled" : "disabled"
+				return {
+					text: `Memory usage display ${state}. Use /memory-usage on|off to set explicitly.`,
+				}
+			}
+
+			return { text: "Usage: /memory-usage [on|off]" }
 		},
 	})
 

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -46,12 +46,16 @@ export function registerCommands(
 
 			if (arg === "on" || arg === "true" || arg === "enable") {
 				cfg.showMemoryUsage = true
-				return { text: "Memory usage display enabled. The model will now show how many memories were used." }
+				return {
+					text: "Memory usage display enabled. The model will now show how many memories were used.",
+				}
 			}
 
 			if (arg === "off" || arg === "false" || arg === "disable") {
 				cfg.showMemoryUsage = false
-				return { text: "Memory usage display disabled. The model will no longer show memory counts." }
+				return {
+					text: "Memory usage display disabled. The model will no longer show memory counts.",
+				}
 			}
 
 			if (!arg) {

--- a/config.ts
+++ b/config.ts
@@ -18,6 +18,7 @@ export type SupermemoryConfig = {
 	captureMode: CaptureMode
 	entityContext: string
 	debug: boolean
+	showMemoryUsage: boolean
 	enableCustomContainerTags: boolean
 	customContainers: CustomContainer[]
 	customContainerInstructions: string
@@ -33,6 +34,7 @@ const ALLOWED_KEYS = [
 	"captureMode",
 	"entityContext",
 	"debug",
+	"showMemoryUsage",
 	"enableCustomContainerTags",
 	"customContainers",
 	"customContainerInstructions",
@@ -125,6 +127,7 @@ export function parseConfig(raw: unknown): SupermemoryConfig {
 				? cfg.entityContext.trim()
 				: DEFAULT_ENTITY_CONTEXT,
 		debug: (cfg.debug as boolean) ?? false,
+		showMemoryUsage: (cfg.showMemoryUsage as boolean) ?? true,
 		enableCustomContainerTags:
 			(cfg.enableCustomContainerTags as boolean) ?? false,
 		customContainers,
@@ -149,6 +152,7 @@ export const supermemoryConfigSchema = {
 			captureMode: { type: "string", enum: ["all", "everything"] },
 			entityContext: { type: "string" },
 			debug: { type: "boolean" },
+			showMemoryUsage: { type: "boolean" },
 			enableCustomContainerTags: { type: "boolean" },
 			customContainers: {
 				type: "array",

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -68,6 +68,7 @@ function formatContext(
 	dynamicFacts: string[],
 	searchResults: ProfileSearchResult[],
 	maxResults: number,
+	showMemoryUsage = true,
 ): string | null {
 	const deduped = deduplicateMemories(staticFacts, dynamicFacts, searchResults)
 	const statics = deduped.static.slice(0, maxResults)
@@ -76,6 +77,8 @@ function formatContext(
 
 	if (statics.length === 0 && dynamics.length === 0 && search.length === 0)
 		return null
+
+	const totalMemories = statics.length + dynamics.length + search.length
 
 	const sections: string[] = []
 
@@ -111,7 +114,12 @@ function formatContext(
 	const disclaimer =
 		"Do not proactively bring up memories. Only use them when the conversation naturally calls for it."
 
-	return `<supermemory-context>\n${intro}\n\n${sections.join("\n\n")}\n\n${disclaimer}\n</supermemory-context>`
+	let memoryUsageInstruction = ""
+	if (showMemoryUsage) {
+		memoryUsageInstruction = `\n\nIMPORTANT: At the very beginning of your response, include a brief note indicating how many memories from Supermemory were used to inform your response. Format it as: "[Supermemory: ${totalMemories} memories loaded]" — this helps the user understand that OpenClaw is using their long-term memory. If none of the memories are relevant to the current message, say "[Supermemory: ${totalMemories} memories loaded, 0 used]".`
+	}
+
+	return `<supermemory-context>\n${intro}\n\n${sections.join("\n\n")}\n\n${disclaimer}${memoryUsageInstruction}\n</supermemory-context>`
 }
 
 function countUserTurns(messages: unknown[]): number {
@@ -187,6 +195,7 @@ export function buildRecallHandler(
 				includeProfile ? profile.dynamic : [],
 				profile.searchResults,
 				cfg.maxRecallResults,
+				cfg.showMemoryUsage,
 			)
 
 			const containerContext = formatContainerMetadata(cfg, messageProvider)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -50,6 +50,11 @@
 			"help": "Enable verbose debug logs for API calls and responses",
 			"advanced": true
 		},
+		"showMemoryUsage": {
+			"label": "Show Memory Usage",
+			"help": "Show how many memories were loaded and used in AI responses",
+			"advanced": true
+		},
 		"enableCustomContainerTags": {
 			"label": "Enable Custom Container Tags",
 			"help": "Enable AI-driven routing to custom containers",
@@ -79,6 +84,7 @@
 			"captureMode": { "type": "string", "enum": ["everything", "all"] },
 			"entityContext": { "type": "string", "maxLength": 1500 },
 			"debug": { "type": "boolean" },
+			"showMemoryUsage": { "type": "boolean" },
 			"enableCustomContainerTags": { "type": "boolean" },
 			"customContainers": {
 				"type": "array",


### PR DESCRIPTION
## Summary
This PR adds a new feature to toggle the display of memory usage counts in AI responses. Users can now control whether the model shows how many memories from Supermemory were used to inform each response.

## Key Changes

- **Configuration**: Added `showMemoryUsage` boolean field to `SupermemoryConfig` (defaults to `true`)
- **CLI Setup**: Added interactive prompt during setup to configure memory usage display preference
- **Slash Command**: Implemented `/memory-usage` command to toggle the feature on/off at runtime with support for explicit arguments (`on`/`off`/`true`/`false`/`enable`/`disable`)
- **Memory Context Formatting**: Modified `formatContext()` to conditionally include memory usage instructions in the system prompt based on the configuration
- **Display Output**: When enabled, the model is instructed to include a brief note at the start of responses showing how many memories were loaded and used (e.g., "[Supermemory: 5 memories loaded, 3 used]")
- **Configuration Persistence**: Memory usage preference is saved to and loaded from the plugin configuration file

## Implementation Details

- The feature defaults to `true` (enabled) to provide users with visibility into memory usage by default
- The `/memory-usage` command without arguments toggles the current state
- The memory usage instruction is only added to the system prompt when the feature is enabled, avoiding unnecessary prompt modifications when disabled
- The configuration is properly validated and included in the schema for configuration file parsing

https://claude.ai/code/session_01EZwRqj9GjD6K4pqMPRhe2P