### PR TITLE
feat: add allowedAgents config for memory hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ temp/
 .DS_Store
 pnpm-lock.yaml
 package-lock.json
+pnpm-lock.yaml.worktrees/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Or configure in `~/.openclaw/openclaw.json`:
 | `enableCustomContainerTags`   | `boolean` | `false`               | Enable custom container routing.                          |
 | `customContainers`            | `array`   | `[]`                  | Custom containers with `tag` and `description`.           |
 | `customContainerInstructions` | `string`  | `""`                  | Instructions for AI on container routing.                 |
+| `allowedAgents`               | `string[]`| omitted               | Restrict auto-capture and auto-recall to matching agent session keys. |
 
 ### Full Example
 
@@ -127,7 +128,8 @@ Or configure in `~/.openclaw/openclaw.json`:
             { "tag": "work", "description": "Work-related memories" },
             { "tag": "personal", "description": "Personal notes" }
           ],
-          "customContainerInstructions": "Store work tasks in 'work', personal stuff in 'personal'"
+          "customContainerInstructions": "Store work tasks in 'work', personal stuff in 'personal'",
+          "allowedAgents": ["navi", "heimerdinger"]
         }
       }
     }

--- a/allowed-agents.test.ts
+++ b/allowed-agents.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, mock } from "bun:test"
+import { parseConfig } from "./config.ts"
+import { buildCaptureHandler } from "./hooks/capture.ts"
+import { buildRecallHandler } from "./hooks/recall.ts"
+
+describe("allowedAgents config", () => {
+	it("parses allowedAgents from config", () => {
+		const cfg = parseConfig({
+			apiKey: "test-key",
+			allowedAgents: ["navi", "heimerdinger"],
+		})
+
+		expect(cfg.allowedAgents).toEqual(["navi", "heimerdinger"])
+	})
+
+	it("skips capture when sessionKey does not match allowedAgents", async () => {
+		const addMemory = mock(async () => undefined)
+		const handler = buildCaptureHandler(
+			{ addMemory } as never,
+			parseConfig({ apiKey: "test-key", allowedAgents: ["navi"] }),
+			() => "agent:heimerdinger:main",
+		)
+
+		await handler(
+			{
+				success: true,
+				messages: [{ role: "user", content: "hello" }],
+			},
+			{ messageProvider: "discord", sessionKey: "agent:heimerdinger:main" },
+		)
+
+		expect(addMemory).not.toHaveBeenCalled()
+	})
+
+	it("skips recall when sessionKey does not match allowedAgents", async () => {
+		const getProfile = mock(async () => ({
+			static: ["persistent fact"],
+			dynamic: [],
+			searchResults: [],
+		}))
+		const handler = buildRecallHandler(
+			{ getProfile } as never,
+			parseConfig({ apiKey: "test-key", allowedAgents: ["navi"] }),
+		)
+
+		const result = await handler(
+			{
+				prompt: "Tell me what you remember about me",
+				messages: [{ role: "user", content: "hello" }],
+			},
+			{ messageProvider: "discord", sessionKey: "agent:heimerdinger:main" },
+		)
+
+		expect(result).toBeUndefined()
+		expect(getProfile).not.toHaveBeenCalled()
+	})
+})

--- a/allowed-agents.test.ts
+++ b/allowed-agents.test.ts
@@ -32,6 +32,47 @@ describe("allowedAgents config", () => {
 		expect(addMemory).not.toHaveBeenCalled()
 	})
 
+	it("processes capture when sessionKey is undefined (no silent data loss)", async () => {
+		const addMemory = mock(async () => undefined)
+		const handler = buildCaptureHandler(
+			{ addMemory } as never,
+			parseConfig({ apiKey: "test-key", allowedAgents: ["navi"] }),
+			() => undefined,
+		)
+
+		await handler(
+			{
+				success: true,
+				messages: [{ role: "user", content: "hello" }],
+			},
+			{ messageProvider: "discord" },
+		)
+
+		expect(addMemory).toHaveBeenCalled()
+	})
+
+	it("processes recall when sessionKey is undefined (no silent data loss)", async () => {
+		const getProfile = mock(async () => ({
+			static: ["persistent fact"],
+			dynamic: [],
+			searchResults: [],
+		}))
+		const handler = buildRecallHandler(
+			{ getProfile } as never,
+			parseConfig({ apiKey: "test-key", allowedAgents: ["navi"] }),
+		)
+
+		const result = await handler(
+			{
+				prompt: "Tell me what you remember about me",
+				messages: [{ role: "user", content: "hello" }],
+			},
+			{ messageProvider: "discord" },
+		)
+
+		expect(getProfile).toHaveBeenCalled()
+	})
+
 	it("skips recall when sessionKey does not match allowedAgents", async () => {
 		const getProfile = mock(async () => ({
 			static: ["persistent fact"],

--- a/allowed-agents.test.ts
+++ b/allowed-agents.test.ts
@@ -18,7 +18,6 @@ describe("allowedAgents config", () => {
 		const handler = buildCaptureHandler(
 			{ addMemory } as never,
 			parseConfig({ apiKey: "test-key", allowedAgents: ["navi"] }),
-			() => "agent:heimerdinger:main",
 		)
 
 		await handler(
@@ -37,7 +36,6 @@ describe("allowedAgents config", () => {
 		const handler = buildCaptureHandler(
 			{ addMemory } as never,
 			parseConfig({ apiKey: "test-key", allowedAgents: ["navi"] }),
-			() => undefined,
 		)
 
 		await handler(

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "supermemory": "^4.0.0",
       },
       "devDependencies": {
+        "@types/bun": "1.3.14",
         "esbuild": "^0.27.2",
         "typescript": "^5.9.3",
       },
@@ -418,11 +419,13 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/events": ["@types/events@3.0.3", "", {}, "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="],
 
     "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
 
-    "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+    "@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
@@ -481,6 +484,8 @@
     "buffer-fill": ["buffer-fill@1.0.0", "", {}, "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1006,7 +1011,7 @@
 
     "undici": ["undici@8.0.2", "", {}, "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unhomoglyph": ["unhomoglyph@1.0.6", "", {}, "sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg=="],
 
@@ -1076,6 +1081,8 @@
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
+    "@line/bot-sdk/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
     "@mariozechner/pi-ai/@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@mariozechner/pi-ai/proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
@@ -1085,8 +1092,6 @@
     "@mariozechner/pi-coding-agent/file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
 
     "@mariozechner/pi-coding-agent/undici": ["undici@7.22.0", "", {}, "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="],
-
-    "@types/yauzl/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1127,8 +1132,6 @@
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
-
-    "protobufjs/@types/node": ["@types/node@25.3.5", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA=="],
 
     "proxy-addr/ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -1172,6 +1175,8 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "@line/bot-sdk/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@mariozechner/pi-ai/proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "@mariozechner/pi-ai/proxy-agent/http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
@@ -1183,8 +1188,6 @@
     "@mariozechner/pi-ai/proxy-agent/socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "@mariozechner/pi-coding-agent/file-type/strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
-
-    "@types/yauzl/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -1203,8 +1206,6 @@
     "node-edge-tts/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "node-edge-tts/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "protobufjs/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "rimraf/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 

--- a/config.ts
+++ b/config.ts
@@ -23,6 +23,7 @@ export type SupermemoryConfig = {
 	enableCustomContainerTags: boolean
 	customContainers: CustomContainer[]
 	customContainerInstructions: string
+	allowedAgents?: string[]
 }
 
 const ALLOWED_KEYS = [
@@ -40,6 +41,7 @@ const ALLOWED_KEYS = [
 	"enableCustomContainerTags",
 	"customContainers",
 	"customContainerInstructions",
+	"allowedAgents",
 ]
 
 function assertAllowedKeys(
@@ -142,6 +144,13 @@ export function parseConfig(raw: unknown): SupermemoryConfig {
 		}
 	}
 
+	const allowedAgents = Array.isArray(cfg.allowedAgents)
+		? cfg.allowedAgents.filter(
+				(agentId): agentId is string =>
+					typeof agentId === "string" && agentId.trim().length > 0,
+			)
+		: undefined
+
 	return {
 		apiKey,
 		baseUrl: resolveBaseUrl(cfg.baseUrl),
@@ -169,6 +178,7 @@ export function parseConfig(raw: unknown): SupermemoryConfig {
 			typeof cfg.customContainerInstructions === "string"
 				? cfg.customContainerInstructions
 				: "",
+		allowedAgents,
 	}
 }
 
@@ -201,6 +211,10 @@ export const supermemoryConfigSchema = {
 				},
 			},
 			customContainerInstructions: { type: "string" },
+			allowedAgents: {
+				type: "array",
+				items: { type: "string" },
+			},
 		},
 	},
 	parse: parseConfig,

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -44,7 +44,6 @@ export function buildCaptureHandler(
 			return
 		}
 
-
 		log.info(
 			`agent_end fired: provider="${ctx.messageProvider}" success=${event.success}`,
 		)

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -35,6 +35,15 @@ export function buildCaptureHandler(
 			return
 		}
 
+		const sessionKey = ctx.sessionKey as string | undefined
+		if (
+			cfg.allowedAgents?.length &&
+			!cfg.allowedAgents.some((agentId) => sessionKey?.includes(agentId))
+		) {
+			return
+		}
+
+
 		log.info(
 			`agent_end fired: provider="${ctx.messageProvider}" success=${event.success}`,
 		)

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -37,8 +37,9 @@ export function buildCaptureHandler(
 
 		const sessionKey = ctx.sessionKey as string | undefined
 		if (
+			sessionKey &&
 			cfg.allowedAgents?.length &&
-			!cfg.allowedAgents.some((agentId) => sessionKey?.includes(agentId))
+			!cfg.allowedAgents.some((agentId) => sessionKey.includes(agentId))
 		) {
 			return
 		}

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -187,8 +187,9 @@ export function buildRecallHandler(
 
 		const sessionKey = ctx?.sessionKey as string | undefined
 		if (
+			sessionKey &&
 			cfg.allowedAgents?.length &&
-			!cfg.allowedAgents.some((agentId) => sessionKey?.includes(agentId))
+			!cfg.allowedAgents.some((agentId) => sessionKey.includes(agentId))
 		) {
 			return
 		}

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -185,6 +185,14 @@ export function buildRecallHandler(
 			return
 		}
 
+		const sessionKey = ctx?.sessionKey as string | undefined
+		if (
+			cfg.allowedAgents?.length &&
+			!cfg.allowedAgents.some((agentId) => sessionKey?.includes(agentId))
+		) {
+			return
+		}
+
 		const rawPrompt = event.prompt as string | undefined
 		if (!rawPrompt || rawPrompt.length < 5) return
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"url": "https://github.com/supermemoryai/openclaw-supermemory.git"
 	},
 	"devDependencies": {
+		"@types/bun": "1.3.14",
 		"esbuild": "^0.27.2",
 		"typescript": "^5.9.3"
 	}


### PR DESCRIPTION
## Summary
- add `allowedAgents?: string[]` to plugin config parsing and schema
- skip auto-capture when the current `sessionKey` does not match an allowed agent
- skip auto-recall when the current `sessionKey` does not match an allowed agent
- document the new config option in the README
- add tests covering config parsing and the new capture/recall guards

Closes #27.

## Behavior
When `allowedAgents` is omitted, behavior stays the same as today.

When `allowedAgents` is set, auto-capture and auto-recall only run for sessions whose `sessionKey` includes one of the configured agent IDs, for example `agent:navi:main`.

## Test plan
- `bun test allowed-agents.test.ts`
- `bun run check-types`
- `bun run lint`
