### PR TITLE
fix: cache plugin initialization to prevent re-init on every tool call (fixes #12)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,9 @@ import { registerProfileTool } from "./tools/profile.ts"
 import { registerSearchTool } from "./tools/search.ts"
 import { registerStoreTool } from "./tools/store.ts"
 
+// Track initialization state to prevent re-registration
+let _initialized = false
+
 export default {
 	id: "openclaw-supermemory",
 	name: "Supermemory",
@@ -19,6 +22,12 @@ export default {
 	configSchema: supermemoryConfigSchema,
 
 	register(api: OpenClawPluginApi) {
+		// Guard against re-initialization
+		if (_initialized) {
+			return
+		}
+		_initialized = true
+
 		const cfg = parseConfig(api.pluginConfig)
 
 		initLogger(api.logger, cfg.debug)


### PR DESCRIPTION
## Problem

The plugin re-initializes on every tool execution, causing 1-2 second delays per operation and showing `supermemory: initialized` repeatedly in logs. As reported in #12, users see 14+ initializations in 6 minutes during normal operation.

## Root Cause

OpenClaw calls `register()` multiple times (on every tool execution or agent start). The plugin was not guarding against this, so it created a new `SupermemoryClient`, re-registered all hooks and tools, and logged "initialized" each time.

## Fix

Add a module-level `_initialized` flag. The `register()` function returns early if already initialized, ensuring:
- Client creation happens once
- Hook registration happens once  
- Tool registration happens once
- The "initialized" log appears exactly once

## Changes

- `index.ts`: Added `_initialized` guard at the top of `register()`

## Testing

- The fix is a simple boolean guard with no side effects
- Type checking can't run locally without `node_modules`, but the change is syntactically minimal (9 lines added)
- No behavioral change for the first initialization call

Fixes #12