### PR TITLE
feat: add allowedAgents config for per-agent memory isolation

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -21,6 +21,7 @@ export type SupermemoryConfig = {
 	enableCustomContainerTags: boolean
 	customContainers: CustomContainer[]
 	customContainerInstructions: string
+	allowedAgents: string[] | undefined
 }
 
 const ALLOWED_KEYS = [
@@ -36,6 +37,7 @@ const ALLOWED_KEYS = [
 	"enableCustomContainerTags",
 	"customContainers",
 	"customContainerInstructions",
+	"allowedAgents",
 ]
 
 function assertAllowedKeys(
@@ -107,6 +109,12 @@ export function parseConfig(raw: unknown): SupermemoryConfig {
 		}
 	}
 
+	const allowedAgents: string[] | undefined = Array.isArray(cfg.allowedAgents)
+		? (cfg.allowedAgents as string[]).filter(
+				(item) => typeof item === "string" && item.length > 0,
+			)
+		: undefined
+
 	return {
 		apiKey,
 		containerTag: cfg.containerTag
@@ -132,6 +140,7 @@ export function parseConfig(raw: unknown): SupermemoryConfig {
 			typeof cfg.customContainerInstructions === "string"
 				? cfg.customContainerInstructions
 				: "",
+		allowedAgents,
 	}
 }
 
@@ -162,7 +171,20 @@ export const supermemoryConfigSchema = {
 				},
 			},
 			customContainerInstructions: { type: "string" },
+			allowedAgents: {
+				type: "array",
+				items: { type: "string" },
+			},
 		},
 	},
 	parse: parseConfig,
+}
+
+export function isAgentAllowed(
+	cfg: SupermemoryConfig,
+	ctx: Record<string, unknown>,
+): boolean {
+	if (!cfg.allowedAgents || cfg.allowedAgents.length === 0) return true
+	const agentId = ctx.agentId as string | undefined
+	return agentId ? cfg.allowedAgents.includes(agentId) : true
 }

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -1,5 +1,6 @@
 import type { SupermemoryClient } from "../client.ts"
 import type { SupermemoryConfig } from "../config.ts"
+import { isAgentAllowed } from "../config.ts"
 import { log } from "../logger.ts"
 import { buildDocumentId } from "../memory.ts"
 
@@ -30,6 +31,11 @@ export function buildCaptureHandler(
 		event: Record<string, unknown>,
 		ctx: Record<string, unknown>,
 	) => {
+		if (!isAgentAllowed(cfg, ctx)) {
+			log.debug(`capture skipped: agent not in allowedAgents list`)
+			return
+		}
+
 		log.info(
 			`agent_end fired: provider="${ctx.messageProvider}" success=${event.success}`,
 		)

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -1,5 +1,6 @@
 import type { ProfileSearchResult, SupermemoryClient } from "../client.ts"
 import type { SupermemoryConfig } from "../config.ts"
+import { isAgentAllowed } from "../config.ts"
 import { log } from "../logger.ts"
 
 function formatRelativeTime(isoTimestamp: string): string {
@@ -170,6 +171,11 @@ export function buildRecallHandler(
 		event: Record<string, unknown>,
 		ctx?: Record<string, unknown>,
 	) => {
+		if (ctx && !isAgentAllowed(cfg, ctx)) {
+			log.debug(`recall skipped: agent not in allowedAgents list`)
+			return
+		}
+
 		const prompt = event.prompt as string | undefined
 		if (!prompt || prompt.length < 5) return
 


### PR DESCRIPTION
## Summary

Adds an optional `allowedAgents` config option to restrict memory operations (recall and capture) to specific agents. Fixes #27.

## Problem

In multi-agent OpenClaw setups, the supermemory plugin fires for every agent that shares the instance. Memories meant for one agent bleed into unrelated agent sessions.

## Solution

New config option:

```json
{
  "plugins": {
    "entries": {
      "openclaw-supermemory": {
        "config": {
          "allowedAgents": ["navi", "research-bot"]
        }
      }
    }
  }
}
```

When `allowedAgents` is set, both `before_agent_start` (recall) and `agent_end` (capture) hooks check `ctx.agentId` against the list. Non-matching agents are silently skipped with a debug log.

When `allowedAgents` is omitted or empty, all agents are allowed (preserving current behavior — no breaking changes).

## Changes

- **config.ts**: Added `allowedAgents` field to config type, parsing, JSON schema, and `isAgentAllowed()` helper
- **hooks/recall.ts**: Guard clause using `isAgentAllowed()`
- **hooks/capture.ts**: Guard clause using `isAgentAllowed()`

3 files changed, +34 lines.

## Notes

- Uses `ctx.agentId` (not `ctx.sessionKey` as suggested in #27) since agentId is the stable identifier for which agent is running
- Follows the existing `SKIPPED_PROVIDERS` pattern in capture.ts for guard precedent
- `isAgentAllowed()` is exported from config.ts for potential reuse in tools/commands if needed later