### PR TITLE
fix: replace broken stringEnum import with inline equivalent

### DIFF
--- a/tools/store.ts
+++ b/tools/store.ts
@@ -1,6 +1,5 @@
 import { Type } from "@sinclair/typebox"
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import { stringEnum } from "openclaw/plugin-sdk"
 import type { SupermemoryClient } from "../client.ts"
 import type { SupermemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"
@@ -9,6 +8,12 @@ import {
 	detectCategory,
 	MEMORY_CATEGORIES,
 } from "../memory.ts"
+
+// stringEnum is declared in plugin-sdk types but not exported at runtime,
+// so we inline the equivalent using Type.Union + Type.Literal.
+function stringEnum<T extends string>(values: readonly T[]) {
+	return Type.Union(values.map((v) => Type.Literal(v)))
+}
 
 export function registerStoreTool(
 	api: OpenClawPluginApi,


### PR DESCRIPTION
## Summary

- Replace the broken `stringEnum` import from `openclaw/plugin-sdk` with an inline equivalent using `Type.Union` + `Type.Literal` from `@sinclair/typebox`
- `stringEnum` is declared in the plugin-sdk type definitions but is not available as a runtime export, causing the plugin to crash on register with `TypeError: (0 , _pluginSdk.stringEnum) is not a function`
- The inline function produces identical schema output without depending on the plugin-sdk internal

Fixes #31

## Test plan

- [ ] Verified the fix locally — plugin registers and starts without errors
- [ ] `stringEnum(MEMORY_CATEGORIES)` produces the same `Type.Union` schema as before
- [ ] No other files reference `stringEnum` — this is the only call site