### PR TITLE
fix: use before_prompt_build for auto recall

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,7 @@ export default {
 		if (cfg.autoRecall) {
 			const recallHandler = buildRecallHandler(client, cfg)
 			api.on(
-				"before_agent_start",
+				"before_prompt_build",
 				(event: Record<string, unknown>, ctx: Record<string, unknown>) => {
 					if (ctx.sessionKey) sessionKey = ctx.sessionKey as string
 					return recallHandler(event, ctx)


### PR DESCRIPTION
This updates auto-recall to use `before_prompt_build` instead of the legacy `before_agent_start` hook.

The recall flow itself is unchanged. This just aligns the plugin with OpenClaw’s current recommended hook for prompt injection and removes the compatibility warning reported by `openclaw doctor`.

Tested with:
- `npm run check-types`
