### PR TITLE
fix: remove stringEnum dep from openclaw plugin-sdk

### DIFF
--- a/tools/store.ts
+++ b/tools/store.ts
@@ -1,64 +1,67 @@
-import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
-import { stringEnum } from "openclaw/plugin-sdk/core"
-import type { SupermemoryClient } from "../client.ts"
-import type { SupermemoryConfig } from "../config.ts"
-import { log } from "../logger.ts"
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { SupermemoryClient } from "../client.ts";
+import type { SupermemoryConfig } from "../config.ts";
+import { log } from "../logger.ts";
 import {
-	buildDocumentId,
-	detectCategory,
-	MEMORY_CATEGORIES,
-} from "../memory.ts"
+  buildDocumentId,
+  detectCategory,
+  MEMORY_CATEGORIES,
+} from "../memory.ts";
 
 export function registerStoreTool(
-	api: OpenClawPluginApi,
-	client: SupermemoryClient,
-	cfg: SupermemoryConfig,
-	getSessionKey: () => string | undefined,
+  api: OpenClawPluginApi,
+  client: SupermemoryClient,
+  cfg: SupermemoryConfig,
+  getSessionKey: () => string | undefined,
 ): void {
-	api.registerTool(
-		{
-			name: "supermemory_store",
-			label: "Memory Store",
-			description: "Save important information to long-term memory.",
-			parameters: Type.Object({
-				text: Type.String({ description: "Information to remember" }),
-				category: Type.Optional(stringEnum(MEMORY_CATEGORIES)),
-				containerTag: Type.Optional(
-					Type.String({
-						description:
-							"Optional container tag to store the memory in a specific container",
-					}),
-				),
-			}),
-			async execute(
-				_toolCallId: string,
-				params: { text: string; category?: string; containerTag?: string },
-			) {
-				const category = params.category ?? detectCategory(params.text)
-				const sk = getSessionKey()
-				const customId = sk ? buildDocumentId(sk) : undefined
+  api.registerTool(
+    {
+      name: "supermemory_store",
+      label: "Memory Store",
+      description: "Save important information to long-term memory.",
+      parameters: Type.Object({
+        text: Type.String({ description: "Information to remember" }),
+        category: Type.Optional(
+          Type.Unsafe<string>({ type: "string", enum: [...MEMORY_CATEGORIES] }),
+        ),
+        containerTag: Type.Optional(
+          Type.String({
+            description:
+              "Optional container tag to store the memory in a specific container",
+          }),
+        ),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: { text: string; category?: string; containerTag?: string },
+      ) {
+        const category = params.category ?? detectCategory(params.text);
+        const sk = getSessionKey();
+        const customId = sk ? buildDocumentId(sk) : undefined;
 
-				log.debug(
-					`store tool: category="${category}" customId="${customId}" containerTag="${params.containerTag ?? "default"}"`,
-				)
+        log.debug(
+          `store tool: category="${category}" customId="${customId}" containerTag="${params.containerTag ?? "default"}"`,
+        );
 
-				await client.addMemory(
-					params.text,
-					{ type: category, source: "openclaw_tool" },
-					customId,
-					params.containerTag,
-					cfg.entityContext,
-				)
+        await client.addMemory(
+          params.text,
+          { type: category, source: "openclaw_tool" },
+          customId,
+          params.containerTag,
+          cfg.entityContext,
+        );
 
-				const preview =
-					params.text.length > 80 ? `${params.text.slice(0, 80)}…` : params.text
+        const preview =
+          params.text.length > 80
+            ? `${params.text.slice(0, 80)}…`
+            : params.text;
 
-				return {
-					content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
-				}
-			},
-		},
-		{ name: "supermemory_store" },
-	)
+        return {
+          content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
+        };
+      },
+    },
+    { name: "supermemory_store" },
+  );
 }

--- a/tools/store.ts
+++ b/tools/store.ts
@@ -1,67 +1,65 @@
-import { Type } from "@sinclair/typebox";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import type { SupermemoryClient } from "../client.ts";
-import type { SupermemoryConfig } from "../config.ts";
-import { log } from "../logger.ts";
+import { Type } from "@sinclair/typebox"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { SupermemoryClient } from "../client.ts"
+import type { SupermemoryConfig } from "../config.ts"
+import { log } from "../logger.ts"
 import {
-  buildDocumentId,
-  detectCategory,
-  MEMORY_CATEGORIES,
-} from "../memory.ts";
+	buildDocumentId,
+	detectCategory,
+	MEMORY_CATEGORIES,
+} from "../memory.ts"
 
 export function registerStoreTool(
-  api: OpenClawPluginApi,
-  client: SupermemoryClient,
-  cfg: SupermemoryConfig,
-  getSessionKey: () => string | undefined,
+	api: OpenClawPluginApi,
+	client: SupermemoryClient,
+	cfg: SupermemoryConfig,
+	getSessionKey: () => string | undefined,
 ): void {
-  api.registerTool(
-    {
-      name: "supermemory_store",
-      label: "Memory Store",
-      description: "Save important information to long-term memory.",
-      parameters: Type.Object({
-        text: Type.String({ description: "Information to remember" }),
-        category: Type.Optional(
-          Type.Unsafe<string>({ type: "string", enum: [...MEMORY_CATEGORIES] }),
-        ),
-        containerTag: Type.Optional(
-          Type.String({
-            description:
-              "Optional container tag to store the memory in a specific container",
-          }),
-        ),
-      }),
-      async execute(
-        _toolCallId: string,
-        params: { text: string; category?: string; containerTag?: string },
-      ) {
-        const category = params.category ?? detectCategory(params.text);
-        const sk = getSessionKey();
-        const customId = sk ? buildDocumentId(sk) : undefined;
+	api.registerTool(
+		{
+			name: "supermemory_store",
+			label: "Memory Store",
+			description: "Save important information to long-term memory.",
+			parameters: Type.Object({
+				text: Type.String({ description: "Information to remember" }),
+				category: Type.Optional(
+					Type.Unsafe<string>({ type: "string", enum: [...MEMORY_CATEGORIES] }),
+				),
+				containerTag: Type.Optional(
+					Type.String({
+						description:
+							"Optional container tag to store the memory in a specific container",
+					}),
+				),
+			}),
+			async execute(
+				_toolCallId: string,
+				params: { text: string; category?: string; containerTag?: string },
+			) {
+				const category = params.category ?? detectCategory(params.text)
+				const sk = getSessionKey()
+				const customId = sk ? buildDocumentId(sk) : undefined
 
-        log.debug(
-          `store tool: category="${category}" customId="${customId}" containerTag="${params.containerTag ?? "default"}"`,
-        );
+				log.debug(
+					`store tool: category="${category}" customId="${customId}" containerTag="${params.containerTag ?? "default"}"`,
+				)
 
-        await client.addMemory(
-          params.text,
-          { type: category, source: "openclaw_tool" },
-          customId,
-          params.containerTag,
-          cfg.entityContext,
-        );
+				await client.addMemory(
+					params.text,
+					{ type: category, source: "openclaw_tool" },
+					customId,
+					params.containerTag,
+					cfg.entityContext,
+				)
 
-        const preview =
-          params.text.length > 80
-            ? `${params.text.slice(0, 80)}…`
-            : params.text;
+				const preview =
+					params.text.length > 80 ? `${params.text.slice(0, 80)}…` : params.text
 
-        return {
-          content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
-        };
-      },
-    },
-    { name: "supermemory_store" },
-  );
+				return {
+					content: [{ type: "text" as const, text: `Stored: "${preview}"` }],
+				}
+			},
+		},
+		{ name: "supermemory_store" },
+	)
 }

--- a/types/openclaw.d.ts
+++ b/types/openclaw.d.ts
@@ -18,7 +18,4 @@ declare module "openclaw/plugin-sdk" {
 		// biome-ignore lint/suspicious/noExplicitAny: openclaw SDK does not ship types
 		on(event: string, handler: (...args: any[]) => any): void
 	}
-
-	// biome-ignore lint/suspicious/noExplicitAny: openclaw SDK does not ship types
-	export function stringEnum(values: readonly string[]): any
 }


### PR DESCRIPTION
#### fix: remove stringEnum dependency to prevent crash on newer openclaw

- tools/store.ts — replaced stringEnum(MEMORY_CATEGORIES) with Type.Unsafe<string>({ type: "string", enum:
  [...MEMORY_CATEGORIES] })
- types/openclaw.d.ts — removed unused stringEnum declaration