### PR TITLE
[codex] Fix OpenClaw 2026.5.7 plugin compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "openclaw": ">=2026.2.17",
+        "openclaw": ">=2026.5.7",
       },
     },
   },

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -4,10 +4,12 @@ import * as path from "node:path"
 import * as readline from "node:readline"
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { SupermemoryClient } from "../client.ts"
-import type { SupermemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"
 
-export function registerCliSetup(api: OpenClawPluginApi): void {
+export function registerCli(
+	api: OpenClawPluginApi,
+	client?: SupermemoryClient,
+): void {
 	api.registerCli(
 		// biome-ignore lint/suspicious/noExplicitAny: openclaw SDK does not ship types
 		({ program }: { program: any }) => {
@@ -60,6 +62,9 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 
 					entries["openclaw-supermemory"] = {
 						enabled: true,
+						hooks: {
+							allowConversationAccess: true,
+						},
 						config: {
 							apiKey: apiKey.trim(),
 						},
@@ -289,6 +294,9 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 
 					entries["openclaw-supermemory"] = {
 						enabled: true,
+						hooks: {
+							allowConversationAccess: true,
+						},
 						config: pluginConfig,
 					}
 
@@ -418,24 +426,8 @@ export function registerCliSetup(api: OpenClawPluginApi): void {
 					console.log(`  Container count:  ${customContainers.length}`)
 					console.log("")
 				})
-		},
-		{ commands: ["supermemory"] },
-	)
-}
 
-export function registerCli(
-	api: OpenClawPluginApi,
-	client: SupermemoryClient,
-	_cfg: SupermemoryConfig,
-): void {
-	api.registerCli(
-		// biome-ignore lint/suspicious/noExplicitAny: openclaw SDK does not ship types
-		({ program }: { program: any }) => {
-			const cmd = program.commands.find(
-				// biome-ignore lint/suspicious/noExplicitAny: openclaw SDK does not ship types
-				(c: any) => c.name() === "supermemory",
-			)
-			if (!cmd) return
+			if (!client) return
 
 			cmd
 				.command("search")
@@ -512,6 +504,14 @@ export function registerCli(
 					console.log(`Wiped ${result.deletedCount} memories from "${tag}".`)
 				})
 		},
-		{ commands: ["supermemory"] },
+		{
+			descriptors: [
+				{
+					name: "supermemory",
+					description: "Supermemory long-term memory commands",
+					hasSubcommands: true,
+				},
+			],
+		},
 	)
 }

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import { SupermemoryClient } from "./client.ts"
-import { registerCli, registerCliSetup } from "./commands/cli.ts"
+import { registerCli } from "./commands/cli.ts"
 import { registerCommands, registerStubCommands } from "./commands/slash.ts"
 import { parseConfig, supermemoryConfigSchema } from "./config.ts"
 import { buildCaptureHandler } from "./hooks/capture.ts"
@@ -37,9 +37,8 @@ export default {
 
 		initLogger(api.logger, cfg.debug)
 
-		registerCliSetup(api)
-
 		if (!cfg.apiKey) {
+			registerCli(api)
 			api.logger.info(
 				"supermemory: not configured - run 'openclaw supermemory setup'",
 			)
@@ -48,6 +47,7 @@ export default {
 		}
 
 		const client = new SupermemoryClient(cfg.apiKey, cfg.containerTag)
+		registerCli(api, client)
 
 		const memoryRuntime = buildMemoryRuntime(client)
 		const noopFlushPlan = () => null
@@ -87,7 +87,6 @@ export default {
 		}
 
 		registerCommands(api, client, cfg, getSessionKey)
-		registerCli(api, client, cfg)
 
 		api.registerService({
 			id: "openclaw-supermemory",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,14 @@
 {
 	"id": "openclaw-supermemory",
 	"kind": "memory",
+	"contracts": {
+		"tools": [
+			"supermemory_search",
+			"supermemory_store",
+			"supermemory_forget",
+			"supermemory_profile"
+		]
+	},
 	"uiHints": {
 		"apiKey": {
 			"label": "Supermemory API Key",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@supermemory/openclaw-supermemory",
-	"version": "2.1.11",
+	"version": "2.1.12",
 	"type": "module",
 	"description": "OpenClaw Supermemory memory plugin",
 	"license": "MIT",
@@ -8,19 +8,49 @@
 		"supermemory": "^4.0.0",
 		"@sinclair/typebox": "0.34.47"
 	},
+	"files": [
+		"README.md",
+		"openclaw.plugin.json",
+		"index.ts",
+		"client.ts",
+		"commands",
+		"hooks",
+		"tools",
+		"config.ts",
+		"logger.ts",
+		"memory.ts",
+		"runtime.ts",
+		"types",
+		"lib/validate.d.ts",
+		"lib/validate.js",
+		"dist"
+	],
 	"scripts": {
+		"build": "npm run build:runtime && npm run build:lib",
+		"build:runtime": "esbuild index.ts --bundle --format=esm --platform=node --target=es2022 --external:openclaw --external:openclaw/* --external:supermemory --outfile=dist/index.js",
 		"check-types": "tsc --noEmit",
 		"lint": "bunx @biomejs/biome ci .",
 		"lint:fix": "bunx @biomejs/biome check --write .",
-		"build:lib": "esbuild lib/validate.ts --bundle --minify --format=esm --platform=node --target=es2022 --external:node:crypto --outfile=lib/validate.js"
+		"build:lib": "esbuild lib/validate.ts --bundle --minify --format=esm --platform=node --target=es2022 --external:node:crypto --outfile=lib/validate.js",
+		"prepack": "npm run build"
 	},
 	"peerDependencies": {
-		"openclaw": ">=2026.2.17"
+		"openclaw": ">=2026.5.7"
 	},
 	"openclaw": {
 		"extensions": [
 			"./index.ts"
-		]
+		],
+		"runtimeExtensions": [
+			"./dist/index.js"
+		],
+		"compat": {
+			"pluginApi": ">=2026.5.7",
+			"minGatewayVersion": "2026.5.7"
+		},
+		"build": {
+			"openclawVersion": "2026.5.7"
+		}
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- add compiled runtime packaging via `openclaw.runtimeExtensions` and `prepack` build
- declare Supermemory tool ownership in `openclaw.plugin.json` contracts
- collapse duplicate Supermemory CLI registration into one descriptor-backed registrar
- enable conversation hook access during setup so `agent_end` auto-capture works
- bump plugin release to `2.1.12` and require OpenClaw `>=2026.5.7`

## Root Cause

OpenClaw 2026.5.7 enforces newer plugin contracts: installed packages need compiled JS runtime output, agent tools must be declared in `contracts.tools`, duplicate CLI command roots are rejected, and non-bundled `agent_end` hooks require explicit `hooks.allowConversationAccess=true`.

## Validation

- `npm run build`
- `npm run check-types`
- `npm run lint`
- `npm pack --dry-run --json`
- `openclaw plugins inspect openclaw-supermemory --runtime --json` -> `diagnostics: []`
- `openclaw plugins doctor` -> no plugin issues
- local linked Gateway loaded plugin `2.1.12` from `dist/index.js`
- chat smoke captured marker `openclaw-supermemory-userkey-smoke-20260507-a` and `openclaw supermemory search` found it in Supermemory

## Notes

The remaining local warning is unrelated: `memory-lancedb` is configured but not installed in this OpenClaw profile.