### PR TITLE
fix: prevent memory pollution and API waste on automated runs (Resolves #20)

### DIFF
--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -34,7 +34,10 @@ export function buildCaptureHandler(
 			`agent_end fired: provider="${ctx.messageProvider}" success=${event.success}`,
 		)
 		const provider = ctx.messageProvider as string
-		if (SKIPPED_PROVIDERS.includes(provider)) {
+		const trigger = ctx.trigger as string | undefined
+		const isAutomatedRun = trigger && trigger !== "user" && trigger !== "manual"
+
+		if (isAutomatedRun || SKIPPED_PROVIDERS.includes(provider)) {
 			return
 		}
 

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -2,6 +2,7 @@ import type { SupermemoryClient } from "../client.ts"
 import type { SupermemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"
 import { buildDocumentId, stripInboundMetadata } from "../memory.ts"
+import { isInteractiveTrigger } from "./trigger.ts"
 
 const SKIPPED_PROVIDERS = ["exec-event", "cron-event", "heartbeat"]
 
@@ -30,14 +31,17 @@ export function buildCaptureHandler(
 		event: Record<string, unknown>,
 		ctx: Record<string, unknown>,
 	) => {
+		const trigger = ctx.trigger as string | undefined
+		if (!isInteractiveTrigger(trigger)) {
+			return
+		}
+
 		log.info(
 			`agent_end fired: provider="${ctx.messageProvider}" success=${event.success}`,
 		)
 		const provider = ctx.messageProvider as string
-		const trigger = ctx.trigger as string | undefined
-		const isAutomatedRun = trigger && trigger !== "user" && trigger !== "manual"
 
-		if (isAutomatedRun || SKIPPED_PROVIDERS.includes(provider)) {
+		if (SKIPPED_PROVIDERS.includes(provider)) {
 			return
 		}
 

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -179,6 +179,11 @@ export function buildRecallHandler(
 		event: Record<string, unknown>,
 		ctx?: Record<string, unknown>,
 	) => {
+		const trigger = ctx?.trigger as string | undefined
+		if (trigger && trigger !== "user" && trigger !== "manual") {
+			return
+		}
+
 		const rawPrompt = event.prompt as string | undefined
 		if (!rawPrompt || rawPrompt.length < 5) return
 

--- a/hooks/recall.ts
+++ b/hooks/recall.ts
@@ -2,6 +2,7 @@ import type { ProfileSearchResult, SupermemoryClient } from "../client.ts"
 import type { SupermemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"
 import { stripInboundMetadata } from "../memory.ts"
+import { isInteractiveTrigger } from "./trigger.ts"
 
 function formatRelativeTime(isoTimestamp: string): string {
 	try {
@@ -180,7 +181,7 @@ export function buildRecallHandler(
 		ctx?: Record<string, unknown>,
 	) => {
 		const trigger = ctx?.trigger as string | undefined
-		if (trigger && trigger !== "user" && trigger !== "manual") {
+		if (!isInteractiveTrigger(trigger)) {
 			return
 		}
 

--- a/hooks/trigger.ts
+++ b/hooks/trigger.ts
@@ -1,0 +1,10 @@
+const INTERACTIVE_TRIGGERS = new Set(["user", "manual"])
+
+export function isInteractiveTrigger(trigger: string | undefined): boolean {
+	// Keep this allowlist in sync with OpenClaw's agent trigger values.
+	// "user" and "manual" are interactive; automated triggers such as
+	// "heartbeat", "cron", "memory", and "overflow" should skip memory hooks.
+	// Undefined preserves legacy behavior for OpenClaw versions that do not
+	// provide ctx.trigger yet.
+	return !trigger || INTERACTIVE_TRIGGERS.has(trigger)
+}


### PR DESCRIPTION
## Summary
Currently, Supermemory executes `recall` and `capture` hooks on all agent turns, including automated background tasks like `heartbeat` and `cron`. This leads to significant token waste and pollutes the memory database with irrelevant background logs.

While there is an existing `SKIPPED_PROVIDERS` array in `capture.ts`, it is insufficient because automated triggers often lack a distinct `messageProvider`. 

Now that the OpenClaw SDK exposes the `trigger` field in the hook context (merged in openclaw/openclaw#24585), we can accurately identify and skip non-interactive automated runs.

## Key Changes
- **hooks/recall.ts**: Safely extracts `ctx.trigger`. If the trigger exists and is NOT `"user"` or `"manual"`, it skips the memory recall process entirely.
- **hooks/capture.ts**: Applies the same trigger-based whitelist before deciding to capture memories, working alongside the existing `SKIPPED_PROVIDERS` check.

## Compatibility
This change is 100% backward compatible. If a user is on an older version of OpenClaw where `ctx.trigger` is `undefined`, the logic safely bypasses the guard and falls back to the legacy behavior.

Resolves #20
