### PR TITLE
add supermemory status slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Everything runs in the cloud. Supermemory handles extraction, deduplication, and
 
 ## Slash Commands
 
-| Command            | Description                             |
-| ------------------ | --------------------------------------- |
-| `/remember <text>` | Manually save something to memory.      |
-| `/recall <query>`  | Search memories with similarity scores. |
+| Command               | Description                             |
+| --------------------- | --------------------------------------- |
+| `/remember <text>`    | Manually save something to memory.      |
+| `/recall <query>`     | Search memories with similarity scores. |
+| `/supermemory-status` | Show Supermemory configuration status.  |
 
 ## AI Tools
 

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -4,7 +4,60 @@ import type { SupermemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"
 import { buildDocumentId, detectCategory } from "../memory.ts"
 
-export function registerStubCommands(api: OpenClawPluginApi): void {
+function maskApiKey(apiKey: string | undefined): string {
+	if (!apiKey) return "not configured"
+	if (apiKey.length <= 12) return "configured"
+	return `${apiKey.slice(0, 8)}...${apiKey.slice(-4)}`
+}
+
+function formatSupermemoryStatus(
+	cfg: SupermemoryConfig,
+	authenticated: boolean,
+): string {
+	const apiKeySource =
+		cfg.apiKey && process.env.SUPERMEMORY_OPENCLAW_API_KEY === cfg.apiKey
+			? "environment"
+			: "plugin config"
+	const customContainerState = cfg.enableCustomContainerTags
+		? "enabled"
+		: "disabled"
+	const lines = [
+		"Supermemory Status",
+		"",
+		`Authenticated: ${authenticated ? "yes" : "no"}`,
+		`API key: ${maskApiKey(cfg.apiKey)}${cfg.apiKey ? ` (${apiKeySource})` : ""}`,
+		`Container tag: ${cfg.containerTag}`,
+		`Auto-recall: ${cfg.autoRecall}`,
+		`Auto-capture: ${cfg.autoCapture}`,
+		`Max recall results: ${cfg.maxRecallResults}`,
+		`Profile frequency: ${cfg.profileFrequency}`,
+		`Capture mode: ${cfg.captureMode}`,
+		`Memory usage display: ${cfg.showMemoryUsage}`,
+		`Custom container tags: ${customContainerState}`,
+		`Custom container count: ${cfg.customContainers.length}`,
+	]
+
+	if (!authenticated) {
+		lines.push("", "Run `openclaw supermemory setup` to connect Supermemory.")
+	}
+
+	return lines.join("\n")
+}
+
+export function registerStubCommands(
+	api: OpenClawPluginApi,
+	cfg: SupermemoryConfig,
+): void {
+	api.registerCommand({
+		name: "supermemory-status",
+		description: "Show Supermemory configuration status",
+		acceptsArgs: false,
+		requireAuth: false,
+		handler: async () => {
+			return { text: formatSupermemoryStatus(cfg, false) }
+		},
+	})
+
 	api.registerCommand({
 		name: "remember",
 		description: "Save something to memory",
@@ -67,6 +120,16 @@ export function registerCommands(
 			}
 
 			return { text: "Usage: /memory-usage [on|off]" }
+		},
+	})
+
+	api.registerCommand({
+		name: "supermemory-status",
+		description: "Show Supermemory configuration status",
+		acceptsArgs: false,
+		requireAuth: false,
+		handler: async () => {
+			return { text: formatSupermemoryStatus(cfg, true) }
 		},
 	})
 

--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ export default {
 			api.logger.info(
 				"supermemory: not configured - run 'openclaw supermemory setup'",
 			)
-			registerStubCommands(api)
+			registerStubCommands(api, cfg)
 			return
 		}
 


### PR DESCRIPTION
## Summary
- Add /supermemory-status as an OpenClaw slash command in both configured and unconfigured plugin states.
- Show masked API key status, container tag, recall/capture settings, memory usage, and custom container settings.
- Document the new slash command in the README.