### PR TITLE
Fix OpenClaw Supermemory onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Long-term memory for OpenClaw. Automatically remembers conversations, recalls re
 openclaw plugins install @supermemory/openclaw-supermemory
 ```
 
-Restart OpenClaw after installing.
-
 ## Setup
 
 ```bash
 openclaw supermemory setup
+openclaw gateway restart
 ```
 
 Enter your API key from [app.supermemory.ai](https://app.supermemory.ai/?view=integrations). That's it.
@@ -26,6 +25,7 @@ Enter your API key from [app.supermemory.ai](https://app.supermemory.ai/?view=in
 
 ```bash
 openclaw supermemory setup-advanced
+openclaw gateway restart
 ```
 
 Configure all options interactively: container tag, auto-recall, auto-capture, capture mode, custom container tags, and more.
@@ -100,9 +100,16 @@ Or configure in `~/.openclaw/openclaw.json`:
 ```json
 {
   "plugins": {
+    "slots": {
+      "memory": "openclaw-supermemory"
+    },
     "entries": {
       "openclaw-supermemory": {
         "enabled": true,
+        "hooks": {
+          "allowPromptInjection": true,
+          "allowConversationAccess": true
+        },
         "config": {
           "apiKey": "${SUPERMEMORY_OPENCLAW_API_KEY}",
           "containerTag": "my_memory",

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -6,6 +6,37 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import type { SupermemoryClient } from "../client.ts"
 import { log } from "../logger.ts"
 
+const SUPERMEMORY_TOOL_NAMES = [
+	"supermemory_store",
+	"supermemory_search",
+	"supermemory_forget",
+	"supermemory_profile",
+]
+
+function appendUniqueStrings(value: unknown, entries: string[]): string[] {
+	const current = Array.isArray(value)
+		? value.filter((item): item is string => typeof item === "string")
+		: []
+	return Array.from(new Set([...current, ...entries]))
+}
+
+function ensureSupermemoryToolsAllowed(config: Record<string, unknown>): void {
+	if (
+		!config.tools ||
+		typeof config.tools !== "object" ||
+		Array.isArray(config.tools)
+	) {
+		config.tools = {}
+	}
+
+	const tools = config.tools as Record<string, unknown>
+	tools.alsoAllow = appendUniqueStrings(tools.alsoAllow, SUPERMEMORY_TOOL_NAMES)
+
+	if (Array.isArray(tools.allow)) {
+		tools.allow = appendUniqueStrings(tools.allow, SUPERMEMORY_TOOL_NAMES)
+	}
+}
+
 export function registerCli(
 	api: OpenClawPluginApi,
 	client?: SupermemoryClient,
@@ -58,11 +89,16 @@ export function registerCli(
 					if (!config.plugins) config.plugins = {}
 					const plugins = config.plugins as Record<string, unknown>
 					if (!plugins.entries) plugins.entries = {}
+					if (!plugins.slots) plugins.slots = {}
+					ensureSupermemoryToolsAllowed(config)
 					const entries = plugins.entries as Record<string, unknown>
+					const slots = plugins.slots as Record<string, unknown>
+					slots.memory = "openclaw-supermemory"
 
 					entries["openclaw-supermemory"] = {
 						enabled: true,
 						hooks: {
+							allowPromptInjection: true,
 							allowConversationAccess: true,
 						},
 						config: {
@@ -78,7 +114,7 @@ export function registerCli(
 
 					console.log("\n✓ API key saved to ~/.openclaw/openclaw.json")
 					console.log(
-						"  Restart OpenClaw to apply changes: openclaw gateway --force\n",
+						"  Restart OpenClaw to apply changes: openclaw gateway restart\n",
 					)
 				})
 
@@ -280,7 +316,11 @@ export function registerCli(
 					if (!config.plugins) config.plugins = {}
 					const plugins = config.plugins as Record<string, unknown>
 					if (!plugins.entries) plugins.entries = {}
+					if (!plugins.slots) plugins.slots = {}
+					ensureSupermemoryToolsAllowed(config)
 					const entries = plugins.entries as Record<string, unknown>
+					const slots = plugins.slots as Record<string, unknown>
+					slots.memory = "openclaw-supermemory"
 
 					const pluginConfig: Record<string, unknown> = {
 						apiKey: apiKey.trim(),
@@ -314,6 +354,7 @@ export function registerCli(
 					entries["openclaw-supermemory"] = {
 						enabled: true,
 						hooks: {
+							allowPromptInjection: true,
 							allowConversationAccess: true,
 						},
 						config: pluginConfig,
@@ -358,7 +399,7 @@ export function registerCli(
 							`  Routing instructions: "${customContainerInstructions.trim().slice(0, 50)}${customContainerInstructions.length > 50 ? "..." : ""}"`,
 						)
 					}
-					console.log("\nRestart OpenClaw to apply: openclaw gateway --force\n")
+					console.log("\nRestart OpenClaw to apply: openclaw gateway restart\n")
 				})
 
 			cmd

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,12 @@
 {
 	"id": "openclaw-supermemory",
 	"kind": "memory",
+	"commandAliases": [
+		{
+			"name": "supermemory",
+			"cliCommand": "supermemory"
+		}
+	],
 	"contracts": {
 		"tools": [
 			"supermemory_search",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@supermemory/openclaw-supermemory",
-	"version": "2.1.13",
+	"version": "2.1.14",
 	"type": "module",
 	"description": "OpenClaw Supermemory memory plugin",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Fixes the OpenClaw Supermemory npm onboarding flow so users can install the package, run setup, restart the gateway, and actually get Supermemory loaded as the active memory plugin.

## What was broken

The README told npm users to run:

```bash
openclaw plugins install @supermemory/openclaw-supermemory
openclaw supermemory setup
```


### There were three issues:

1. OpenClaw did not know this plugin owned the `supermemory` CLI command.

   The command implementation existed in `commands/cli.ts`, but the plugin manifest did not advertise ownership of the `supermemory` root command.

   OpenClaw routes plugin CLI commands from cold metadata before loading the full plugin runtime, so users could see:

   ```text
   Unknown command: openclaw supermemory.
   No built-in command or plugin CLI metadata owns "supermemory".
   ```

2. The plugin could be installed but not selected as the active memory plugin.

   OpenClaw only allows one plugin to own the memory slot. The default slot is `memory-core`, so `openclaw-supermemory` could be installed and enabled but still effectively disabled.

   In that state, inspection showed:

   ```text
   Error: memory slot set to "memory-core"
   ```

3. Setup granted conversation access but not prompt injection.

   Auto-capture needs conversation access, but auto-recall also needs prompt injection so the plugin can inject recalled memories before an AI turn.

4. Agent cannot access tools

   After installing the npm plugin and running setup, OpenClaw could load the plugin and route the `openclaw supermemory ...` CLI command, but the main agent still could not access the Supermemory tools.

`openclaw supermemory` setup and `openclaw supermemory setup-advanced` now add the Supermemory tools to tools.alsoAllow:

```json
{
  "tools": {
    "alsoAllow": [
      "supermemory_store",
      "supermemory_search",
      "supermemory_forget",
      "supermemory_profile"
    ]
  }
}
```

### Also verified locally with:

```bash
openclaw plugins inspect openclaw-supermemory
```

The plugin reports as loaded, exposes the `supermemory` command, and uses version `2.1.14` and tools also worked