### PR TITLE
add auto update notice

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,11 +9,15 @@ import { parseConfig, supermemoryConfigSchema } from "./config.ts"
 import { buildCaptureHandler } from "./hooks/capture.ts"
 import { buildRecallHandler } from "./hooks/recall.ts"
 import { initLogger } from "./logger.ts"
+import { checkNpmUpdate, formatUpdateNotice } from "./lib/version-check.ts"
 import { buildMemoryRuntime, buildPromptSection } from "./runtime.ts"
 import { registerForgetTool } from "./tools/forget.ts"
 import { registerProfileTool } from "./tools/profile.ts"
 import { registerSearchTool } from "./tools/search.ts"
 import { registerStoreTool } from "./tools/store.ts"
+
+const PLUGIN_VERSION = "2.1.14"
+const UPDATE_COMMAND = "openclaw plugins install @supermemory/openclaw-supermemory"
 
 try {
 	const stateDir =
@@ -96,6 +100,13 @@ export default {
 			id: "openclaw-supermemory",
 			start: () => {
 				api.logger.info("supermemory: connected")
+				void checkNpmUpdate(
+					"@supermemory/openclaw-supermemory",
+					PLUGIN_VERSION,
+					UPDATE_COMMAND,
+				).then((info) => {
+					if (info) api.logger.info(formatUpdateNotice(info))
+				})
 			},
 			stop: () => {
 				api.logger.info("supermemory: stopped")

--- a/lib/version-check.ts
+++ b/lib/version-check.ts
@@ -1,0 +1,78 @@
+const NPM_REGISTRY_URL = "https://registry.npmjs.org";
+const CHECK_TIMEOUT_MS = 3000;
+
+export interface UpdateInfo {
+	currentVersion: string
+	latestVersion: string
+	updateCommand: string
+}
+
+function parseVersion(
+	version: string,
+): { parts: number[]; prerelease: string | null } | null {
+	const normalized = version.trim().replace(/^v/i, "")
+	const match = normalized.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/)
+	if (!match) return null
+
+	return {
+		parts: [Number(match[1]), Number(match[2]), Number(match[3])],
+		prerelease: match[4] ?? null,
+	}
+}
+
+function isVersionNewer(latestVersion: string, currentVersion: string): boolean {
+	const latest = parseVersion(latestVersion)
+	const current = parseVersion(currentVersion)
+	if (!latest || !current) return latestVersion !== currentVersion
+
+	for (let i = 0; i < 3; i++) {
+		const latestPart = latest.parts[i] ?? 0
+		const currentPart = current.parts[i] ?? 0
+		if (latestPart > currentPart) return true
+		if (latestPart < currentPart) return false
+	}
+
+	if (!latest.prerelease && current.prerelease) return true
+	if (latest.prerelease && !current.prerelease) return false
+	return latest.prerelease !== current.prerelease && latest.prerelease !== null
+}
+
+export async function checkNpmUpdate(
+	packageName: string,
+	currentVersion: string,
+	updateCommand: string,
+): Promise<UpdateInfo | null> {
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS)
+
+	try {
+		const encodedPackage = packageName.startsWith("@")
+			? packageName.replace("/", "%2F")
+			: encodeURIComponent(packageName)
+		const response = await fetch(`${NPM_REGISTRY_URL}/${encodedPackage}/latest`, {
+			signal: controller.signal,
+		})
+		if (!response.ok) return null
+
+		const data = (await response.json()) as { version?: unknown }
+		const latestVersion = typeof data.version === "string" ? data.version : null
+		if (!latestVersion || !isVersionNewer(latestVersion, currentVersion)) {
+			return null
+		}
+
+		return { currentVersion, latestVersion, updateCommand }
+	} catch {
+		return null
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+export function formatUpdateNotice(info: UpdateInfo): string {
+	return [
+		"supermemory: update available",
+		`current: v${info.currentVersion}`,
+		`latest: v${info.latestVersion}`,
+		`run: ${info.updateCommand}`,
+	].join(" | ")
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"memory.ts",
 		"runtime.ts",
 		"types",
+		"lib/version-check.ts",
 		"lib/validate.d.ts",
 		"lib/validate.js",
 		"dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
 		"hooks/*.ts",
 		"commands/*.ts",
 		"types/*.d.ts",
+		"lib/*.ts",
 		"lib/*.d.ts"
 	],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Adds a fail-safe npm registry update check to the OpenClaw service start path and logs an update notice when npm has a newer @supermemory/openclaw-supermemory version.