### PR TITLE
bucket capture docs by 6h utc window

### DIFF
--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -34,7 +34,6 @@ export function registerCommands(
 	api: OpenClawPluginApi,
 	client: SupermemoryClient,
 	cfg: SupermemoryConfig,
-	getSessionKey: () => string | undefined,
 ): void {
 	api.registerCommand({
 		name: "memory-usage",
@@ -85,11 +84,10 @@ export function registerCommands(
 
 			try {
 				const category = detectCategory(text)
-				const sk = getSessionKey()
 				const { status } = await client.addMemory(
 					text,
 					{ type: category, source: "openclaw_command" },
-					sk ? buildDocumentId(sk) : undefined,
+					buildDocumentId(),
 					undefined,
 					cfg.entityContext,
 				)

--- a/hooks/capture.ts
+++ b/hooks/capture.ts
@@ -25,7 +25,6 @@ function getLastTurn(messages: unknown[]): unknown[] {
 export function buildCaptureHandler(
 	client: SupermemoryClient,
 	cfg: SupermemoryConfig,
-	getSessionKey: () => string | undefined,
 ) {
 	return async (
 		event: Record<string, unknown>,
@@ -107,11 +106,10 @@ export function buildCaptureHandler(
 		if (captured.length === 0) return
 
 		const content = captured.join("\n\n")
-		const sk = getSessionKey()
-		const customId = sk ? buildDocumentId(sk) : undefined
+		const customId = buildDocumentId()
 
 		log.debug(
-			`capturing ${captured.length} texts (${content.length} chars) → ${customId ?? "no-session-key"}`,
+			`capturing ${captured.length} texts (${content.length} chars) → ${customId}`,
 		)
 
 		try {

--- a/index.ts
+++ b/index.ts
@@ -71,22 +71,12 @@ export default {
 			api.registerMemoryFlushPlan?.(noopFlushPlan)
 		}
 
-		let sessionKey: string | undefined
-		const getSessionKey = () => sessionKey
-
-		api.on(
-			"session_start",
-			(_event: Record<string, unknown>, ctx: Record<string, unknown>) => {
-				if (ctx.sessionKey) sessionKey = ctx.sessionKey as string
-			},
-		)
-
 		registerSearchTool(api, client, cfg)
-		registerStoreTool(api, client, cfg, getSessionKey)
+		registerStoreTool(api, client, cfg)
 		registerForgetTool(api, client, cfg)
 		registerProfileTool(api, client, cfg)
 		registerSearchTool(api, client, cfg, "supermemory-search")
-		registerStoreTool(api, client, cfg, getSessionKey, "supermemory-save")
+		registerStoreTool(api, client, cfg, "supermemory-save")
 		registerForgetTool(api, client, cfg, "supermemory-forget")
 		registerProfileTool(api, client, cfg, "supermemory-profile")
 
@@ -95,10 +85,10 @@ export default {
 		}
 
 		if (cfg.autoCapture) {
-			api.on("agent_end", buildCaptureHandler(client, cfg, getSessionKey))
+			api.on("agent_end", buildCaptureHandler(client, cfg))
 		}
 
-		registerCommands(api, client, cfg, getSessionKey)
+		registerCommands(api, client, cfg)
 
 		api.registerService({
 			id: "openclaw-supermemory",

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,8 @@ import { registerCommands, registerStubCommands } from "./commands/slash.ts"
 import { parseConfig, supermemoryConfigSchema } from "./config.ts"
 import { buildCaptureHandler } from "./hooks/capture.ts"
 import { buildRecallHandler } from "./hooks/recall.ts"
-import { initLogger } from "./logger.ts"
 import { checkNpmUpdate, formatUpdateNotice } from "./lib/version-check.ts"
+import { initLogger } from "./logger.ts"
 import { buildMemoryRuntime, buildPromptSection } from "./runtime.ts"
 import { registerForgetTool } from "./tools/forget.ts"
 import { registerProfileTool } from "./tools/profile.ts"
@@ -17,7 +17,8 @@ import { registerSearchTool } from "./tools/search.ts"
 import { registerStoreTool } from "./tools/store.ts"
 
 const PLUGIN_VERSION = "2.1.14"
-const UPDATE_COMMAND = "openclaw plugins install @supermemory/openclaw-supermemory"
+const UPDATE_COMMAND =
+	"openclaw plugins install @supermemory/openclaw-supermemory"
 
 try {
 	const stateDir =

--- a/memory.ts
+++ b/memory.ts
@@ -99,10 +99,10 @@ export function stripInboundMetadata(text: string): string {
 	return result.join("\n").replace(/^\n+/, "").replace(/\n+$/, "")
 }
 
-export function buildDocumentId(sessionKey: string): string {
-	const sanitized = sessionKey
-		.replace(/[^a-zA-Z0-9_]/g, "_")
-		.replace(/_+/g, "_")
-		.replace(/^_|_$/g, "")
-	return `session_${sanitized}`
+export function buildDocumentId(now: Date = new Date()): string {
+	const yyyy = now.getUTCFullYear()
+	const mm = String(now.getUTCMonth() + 1).padStart(2, "0")
+	const dd = String(now.getUTCDate()).padStart(2, "0")
+	const bucket = Math.floor(now.getUTCHours() / 6)
+	return `session_${yyyy}-${mm}-${dd}_b${bucket}`
 }

--- a/tools/store.ts
+++ b/tools/store.ts
@@ -13,7 +13,6 @@ export function registerStoreTool(
 	api: OpenClawPluginApi,
 	client: SupermemoryClient,
 	cfg: SupermemoryConfig,
-	getSessionKey: () => string | undefined,
 	toolName = "supermemory_store",
 ): void {
 	api.registerTool(
@@ -38,8 +37,7 @@ export function registerStoreTool(
 				params: { text: string; category?: string; containerTag?: string },
 			) {
 				const category = params.category ?? detectCategory(params.text)
-				const sk = getSessionKey()
-				const customId = sk ? buildDocumentId(sk) : undefined
+				const customId = buildDocumentId()
 
 				log.debug(
 					`store tool: category="${category}" customId="${customId}" containerTag="${params.containerTag ?? "default"}"`,


### PR DESCRIPTION
swaps the per-session customId for a 6h UTC time bucket (session_<date>_b0..b3). turns inside the same window share one customId so the backend appends them into one doc, rolls over every 6h. containerTag still separates users.

side effect: drops the sessionKey / session_start plumbing entirely, which is the exact code PR #39 touched. so the "session_start never fires -> customId drops -> every turn becomes its own doc" path is gone.

append-on-same-customId behavior confirmed, so a stable bucket id is all that's needed (no capture change).

still draft for one open thing: confirm customId is scoped per containerTag not global (else two users collide on the same bucket id). not run end to end yet - needs the openclaw runtime + a supermemory key to exercise the agent_end hook.