### PR TITLE
Declare hyphenated tool aliases in plugin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,18 @@ Everything runs in the cloud. Supermemory handles extraction, deduplication, and
 
 The AI uses these tools autonomously. With custom container tags enabled, all tools support a `containerTag` parameter for routing to specific containers.
 
-| Tool                  | Description                                            |
-| --------------------- | ------------------------------------------------------ |
-| `supermemory_store`   | Save information to memory.                            |
-| `supermemory_search`  | Search memories by query.                              |
-| `supermemory_forget`  | Delete a memory by query or ID.                        |
-| `supermemory_profile` | View user profile (persistent facts + recent context). |
+| Tool                    | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `supermemory-save`      | Save information to memory.                            |
+| `supermemory-search`    | Search memories by query.                              |
+| `supermemory-forget`    | Delete a memory by query or ID.                        |
+| `supermemory-profile`   | View user profile (persistent facts + recent context). |
+
+The hyphenated names above are the standard across all Supermemory plugins. The
+older `supermemory_store`, `supermemory_search`, `supermemory_forget` and
+`supermemory_profile` names still work and resolve to the same tools, but they
+are deprecated and will be removed in 3.0. Update any tool allowlists to the
+hyphenated names.
 
 ## CLI Commands
 

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -7,7 +7,12 @@ import type { SupermemoryClient } from "../client.ts"
 import { DEFAULT_BASE_URL } from "../config.ts"
 import { log } from "../logger.ts"
 
+// Hyphenated names are current; snake_case is deprecated and removed in 3.0.
 const SUPERMEMORY_TOOL_NAMES = [
+	"supermemory-save",
+	"supermemory-search",
+	"supermemory-forget",
+	"supermemory-profile",
 	"supermemory_store",
 	"supermemory_search",
 	"supermemory_forget",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -9,6 +9,10 @@
 	],
 	"contracts": {
 		"tools": [
+			"supermemory-search",
+			"supermemory-save",
+			"supermemory-forget",
+			"supermemory-profile",
 			"supermemory_search",
 			"supermemory_store",
 			"supermemory_forget",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@supermemory/openclaw-supermemory",
-	"version": "2.1.15",
+	"version": "2.1.17",
 	"type": "module",
 	"description": "OpenClaw Supermemory memory plugin",
 	"license": "MIT",

--- a/runtime.ts
+++ b/runtime.ts
@@ -111,9 +111,16 @@ export function buildMemoryRuntime(
 export function buildPromptSection(params: {
 	availableTools: Set<string>
 }): string[] {
-	const hasSearch = params.availableTools.has("supermemory_search")
-	const hasStore = params.availableTools.has("supermemory_store")
-	if (!hasSearch && !hasStore) return []
+	// Prefer the hyphenated names; fall back to the deprecated snake_case ones.
+	const pick = (hyphen: string, snake: string): string | null => {
+		if (params.availableTools.has(hyphen)) return hyphen
+		if (params.availableTools.has(snake)) return snake
+		return null
+	}
+
+	const searchTool = pick("supermemory-search", "supermemory_search")
+	const storeTool = pick("supermemory-save", "supermemory_store")
+	if (!searchTool && !storeTool) return []
 
 	const lines: string[] = [
 		"## Memory (Supermemory)",
@@ -123,14 +130,14 @@ export function buildPromptSection(params: {
 		"",
 	]
 
-	if (hasSearch) {
+	if (searchTool) {
 		lines.push(
-			"Use supermemory_search to look up prior conversations, preferences, and facts.",
+			`Use ${searchTool} to look up prior conversations, preferences, and facts.`,
 		)
 	}
-	if (hasStore) {
+	if (storeTool) {
 		lines.push(
-			"Use supermemory_store to save important information the user asks you to remember.",
+			`Use ${storeTool} to save important information the user asks you to remember.`,
 		)
 	}
 


### PR DESCRIPTION
OpenClaw 2026.9.x rejects tool registrations missing from contracts.tools,
so the four hyphenated aliases logged activation errors and never loaded.
Declare them alongside the snake_case names and mark snake_case deprecated
in the README, ahead of removal in 3.0.

Fixes supermemoryai/openclaw-supermemory#63